### PR TITLE
fix remove(0) for empty events

### DIFF
--- a/cpptime.h
+++ b/cpptime.h
@@ -251,7 +251,7 @@ public:
 	bool remove(timer_id id)
 	{
 		scoped_m lock(m);
-		if(events.size() < id) {
+		if(events.size() == 0 || events.size() < id) {
 			return false;
 		}
 		events[id].valid = false;


### PR DESCRIPTION
Fix issue #1 with adding check that events.size() is not 0.