### PR TITLE
Trigger immediate lambda cleanup on remove()

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ alternatives. E.g.
 timer.add(seconds(2), [](CppTime::timer_id) { ... });
 ~~~
 
+- Please note: the callback function's state (e.g., lambda function captured
+variables) are not accessible after calling timer.remove(), including if it's
+removed from inside the callback function itself. This is because the timer
+event has been removed, and has become invalid
+
 - The implementation is small and easy to understand. It is not difficult to
 change to make it better suitable for specific cases.
 

--- a/cpptime.h
+++ b/cpptime.h
@@ -11,7 +11,7 @@
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
+ * furnished to do so, subject to the following conditionsE
  *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
@@ -254,7 +254,8 @@ public:
 		if(events.size() == 0 || events.size() <= id) {
 			return false;
 		}
-		events[id] = detail::Event();
+		events[id].valid = false;
+		events[id].handler = nullptr;
 		auto it = std::find_if(time_events.begin(), time_events.end(),
 		    [&](const detail::Time_event &te) { return te.ref == id; });
 		if(it != time_events.end()) {
@@ -296,6 +297,7 @@ private:
 						// The event is either no longer valid because it was removed in the
 						// callback, or it is a one-shot timer.
 						events[te.ref].valid = false;
+						events[te.ref].handler = nullptr;
 						free_ids.push(te.ref);
 					}
 				} else {

--- a/cpptime.h
+++ b/cpptime.h
@@ -11,7 +11,7 @@
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditionsE
+ * furnished to do so, subject to the following conditions:
  *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.

--- a/cpptime.h
+++ b/cpptime.h
@@ -254,7 +254,7 @@ public:
 		if(events.size() == 0 || events.size() <= id) {
 			return false;
 		}
-		events[id].valid = false;
+		events[id] = detail::Event();
 		auto it = std::find_if(time_events.begin(), time_events.end(),
 		    [&](const detail::Time_event &te) { return te.ref == id; });
 		if(it != time_events.end()) {


### PR DESCRIPTION
This change triggers an immediate lambda cleanup on remove(), so that any related resources can be cleaned up. 

I was getting a SEGV on exit in my program, because the CppTime Event object still existed at exit, causing delayed shared_ptr destruction, which in turn caused a crash with a dangling pointer. This change makes sure that all resources associated with a timer get cleaned up when it's removed.